### PR TITLE
read_table instead of read_delim because iso stopwords only contains …

### DIFF
--- a/_episodes_rmd/03TextminingwithREpisode3.Rmd
+++ b/_episodes_rmd/03TextminingwithREpisode3.Rmd
@@ -80,7 +80,8 @@ A  more extensive stopword list for Danish is the ISO stopword list. We will use
 
 ```{r}
 download.file("https://raw.githubusercontent.com/KUBDatalab/R-textmining/main/data/iso_stopord.txt", "data/iso_stopord.txt", mode = "wb")
-iso_stopwords <- read_delim("data/iso_stopord.txt")
+iso_stopwords <- read_table("data/iso_stopord.txt")
+iso_stopwords <- as_tibble(iso_stopwords)
 ```
 
 Let us now apply it to the dataset by `anti_join`


### PR DESCRIPTION
…one column. as_tibble added to prepare iso stopwords for anti_join

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:


These courses are open for everyone to work with, but are primarily intended for
the courses we offer in KUB Datalab. We welcome every contribution, large or small
from the public, but reserve the right to prioritise contributions that improve
our own teaching.

If you have any questions about the lesson maintenance process or would like to 
contribute, please contact The KUB Datalab Team at kubdatalab@kb.dk.

You may delete these instructions from your comment.

\- The KUB Datalab
</details>
